### PR TITLE
Check if base url is empty

### DIFF
--- a/lib/monitor.ts
+++ b/lib/monitor.ts
@@ -91,7 +91,7 @@ function getErrorMessage(res: express.Response){
  * @returns {string address}
  */
 function getAddress(req: express.Request) : string {
-    if (typeof req.baseUrl === "undefined") {
+    if (typeof req.baseUrl === "undefined" || req.baseUrl === "") {
         return req.originalUrl.split("?")[0];
     }
     return req.baseUrl + (req.route && req.route.path ? req.route.path : "");


### PR DESCRIPTION
There's an issue when the `req.baseUrl` is empty:

```
# HELP request_seconds records in a histogram the number of http requests and their duration in seconds
# TYPE request_seconds histogram
request_seconds_bucket{le="1",type="http",status="200",method="GET",addr="/^(?!\\/metrics$).*/",isError="false",errorMessage=""} 1
request_seconds_bucket{le="+Inf",type="http",status="200",method="GET",addr="/^(?!\\/metrics$).*/",isError="false",errorMessage=""} 1
request_seconds_sum{type="http",status="200",method="GET",addr="/^(?!\\/metrics$).*/",isError="false",errorMessage=""} 0.542632466
request_seconds_count{type="http",status="200",method="GET",addr="/^(?!\\/metrics$).*/",isError="false",errorMessage=""} 1
```

Note the address: `addr="/^(?!\\/metrics$).*/"`.

This PR should fix it by checking if `baseUrl` is empty in `getAddress` method.
